### PR TITLE
Allow demeuking entire (nested) directories using glob expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Examples:
 ```
     demeuk -i inputfile.tmp -o outputfile.dict -d droppedfile.txt
     demeuk -i inputfile -o outputfile -j 24 -l logfile.log
+    demeuk -i inputdir/*.txt -o outputfile.dict -l logfile.log
 ```
 
 ## Docs

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -75,6 +75,7 @@
 """
 
 from binascii import hexlify, unhexlify
+from glob import glob
 from html import unescape
 from inspect import cleandoc
 from locale import LC_ALL, setlocale
@@ -731,17 +732,20 @@ def clean_up(filename, chunk_start, chunk_size, config):
 
 def chunkify(fname, size=1024 * 1024):
     # based on: https://www.blopig.com/blog/2016/08/processing-large-files-using-python/
-    fileend = path.getsize(fname)
-    with open(fname, 'br') as f:
-        chunkend = f.tell()
-        while True:
-            chunkstart = chunkend
-            f.seek(size, 1)
-            f.readline()
+    for filename in glob(fname):
+        if not path.isfile(filename):
+            continue
+        fileend = path.getsize(filename)
+        with open(filename, 'br') as f:
             chunkend = f.tell()
-            yield chunkstart, chunkend - chunkstart
-            if chunkend > fileend:
-                break
+            while True:
+                chunkstart = chunkend
+                f.seek(size, 1)
+                f.readline()
+                chunkend = f.tell()
+                yield chunkstart, chunkend - chunkstart
+                if chunkend > fileend:
+                    break
 
 
 def main():

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -732,7 +732,7 @@ def clean_up(filename, chunk_start, chunk_size, config):
 
 def chunkify(fname, size=1024 * 1024):
     # based on: https://www.blopig.com/blog/2016/08/processing-large-files-using-python/
-    for filename in glob(fname):
+    for filename in glob(fname, recursive=True):
         if not path.isfile(filename):
             continue
         fileend = path.getsize(filename)

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -9,12 +9,14 @@
 
     Examples:
         demeuk -i inputfile.tmp -o outputfile.dict -l logfile.txt
+        demeuk -i inputfile0*.txt -o outputfile.dict -l logfile.txt
+        demeuk -i inputdir/* -o outputfile.dict -l logfile.txt
         demeuk -i inputfile -o outputfile -j 24
         demeuk -i inputfile -o outputfile -c -e
         demeuk -i inputfile -o outputfile --threads all
 
     Standard Options:
-        -i --input <path to file>       Specify the input file to be clean
+        -i --input <path to file>       Specify the input file to be cleaned, or provide a glob pattern
         -o --output <path to file>      Specify the output file name.
         -l --log <path to file>         Optional, specify where the log file needs to be writen to
         -j --threads <threads>          Optional, demeuk doesn't use threads by default. Specify amount of threads to

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -412,3 +412,14 @@ def test_check_bug_comma_d():
         assert 'angus' in filecontent
         assert 'line2' not in filecontent
         assert 'snow' in filecontent
+
+
+def test_glob():
+    testargs = [
+        'demeuk', '-i', 'testdata/input*', '-o', 'testdata/output25', '-l', 'testdata/log25',
+        '--verbose', '-c', '-d', ',;:',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output25') as f:
+        assert len(f.readlines()) == 110


### PR DESCRIPTION
When demeuking the BreachCompilation dataset, I noticed the restriction that demeuk by default processes only one file.

Using `glob`, processing entire directories would be possible, with patterns like:

```demeuk -i ./BreachCompilation/*/* -o demeuked_breachcompilation.dict```
or 
```demeuk -i ./BreachCompilation/** -o demeuked_breachcompilation.dict```

That seemed like a quick win to me. It doesn't break any existing behaviour. <sup>[citation needed]</sup>

If this is considered for a merge, I am willing to 
+ document it
+ add some tests
+ add logging output about the number of matching files so the user gets feedback on the results of the glob expression

(hence the work-in-progress label)

If it's not considered, no hard feelings either, but I will not do the busywork of documenting it and writing tests.