### PR TITLE
Feature replace nonascii

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -178,8 +178,14 @@ check-hash
 Checks if a line contains an hash. If so the line is dropped. The regex used are quite
 simple. One regex check if a line, from start to finish, contains a-f and 0-9's only.
 The other checks if the line contains a structure which looks like linux hash. Something
+like
 
 $1$fjdfh$qwertyuiopjfsdf
+
+check-non-ascii
+~~~~~~~~~~~~~~~
+Checks if a line contains non-ascii chars. It does this by using the 'ascii' encoding
+builtin Python. If the line does not encode correctly the line is dropped.
 
 Modify modules
 --------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -223,6 +223,13 @@ umlaut
 In some spellings website the umlaut is not used correct. For example they are encoded as
 the characters a". This should of course be an a with an umlaut.
 
+non-ascii
+~~~~~~~~~
+Replaces Unicode chars to 7-bit Ascii replacement. For this the following lib is used:
+https://pypi.org/project/Unidecode/
+
+For example a line like 'kožušček' is replaced to kozuscek.
+
 no-mojibake
 ~~~~~~~~~~~
 Use this option to disable the default behavior of trying to fix encoding issues.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ docopt
 chardet
 nltk
 ftfy
+unidecode

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ dependencies = [
     'chardet',
     'nltk',
     'ftfy',
+    'unidecode',
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,3 +170,7 @@ with open('testdata/input24', 'w') as file:
     file.write(f'line1@example.com,angus{linesep}')
     file.write(f'line2@example.com:snow{linesep}')
     file.write(f'line3@example.com:julia{linesep}')
+
+with open('testdata/input25', 'w') as file:
+    file.write(f'laténight{linesep}')
+    file.write(f'thestrokes{linesep}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,3 +174,7 @@ with open('testdata/input24', 'w') as file:
 with open('testdata/input25', 'w') as file:
     file.write(f'laténight{linesep}')
     file.write(f'thestrokes{linesep}')
+
+with open('testdata/input26', 'w') as file:
+    file.write(f'polopaç{linesep}')
+    file.write(f'mündster{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -425,3 +425,19 @@ def test_check_non_ascii():
         filecontent = f.read()
         assert 'laténight' not in filecontent
         assert 'thestrokes' in filecontent
+
+
+def test_clean_non_ascii():
+    testargs = [
+        'demeuk', '-i', 'testdata/input26', '-o', 'testdata/output26', '-l', 'testdata/log26',
+        '--verbose', '--non-ascii',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output26') as f:
+        filecontent = f.read()
+
+        assert 'polopaç' not in filecontent
+        assert 'mündster' not in filecontent
+        assert 'polopac' in filecontent
+        assert 'mundster' in filecontent

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -412,3 +412,16 @@ def test_check_bug_comma_d():
         assert 'angus' in filecontent
         assert 'line2' not in filecontent
         assert 'snow' in filecontent
+
+
+def test_check_non_ascii():
+    testargs = [
+        'demeuk', '-i', 'testdata/input25', '-o', 'testdata/output25', '-l', 'testdata/log25',
+        '--verbose', '--check-non-ascii',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output25') as f:
+        filecontent = f.read()
+        assert 'laténight' not in filecontent
+        assert 'thestrokes' in filecontent


### PR DESCRIPTION
Adding two options

--check-non-ascii, drops lines if a line contains something that is not 7-bit ascii
--non-ascii replaces Unicode chars with their 7-bit ascii replacement