### PR TITLE
Punctuation

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -71,7 +71,8 @@
                                         one char.
 
     Remove modules (remove specific parts of a line):
-        --remove-punctuation            Remove start and ending punctuation.
+        --remove-strip-punctuation      Remove starting and trailing punctuation
+        --remove-punctuation            Remove all punctuation in a line
         --remove-email                  Enable email filter, this will catch strings like
                                         1238661:test@example.com:password
     Macro modules:
@@ -254,7 +255,7 @@ def clean_add_umlaut(line):
         return False, line
 
 
-def remove_punctuation(line):
+def remove_strip_punctuation(line):
     """Returns the line without start and end punctuation
 
     Param:
@@ -714,10 +715,10 @@ def clean_up(filename, chunk_start, chunk_size, config):
                 log.append(f'Check_non_ascii; dropped line because non ascii char found; {line_decoded}{linesep}')
                 stop = True
 
-        if config.get('remove-punctuation') and not stop:
-            status, line_decoded = remove_punctuation(line_decoded)
+        if config.get('remove-strip-punctuation') and not stop:
+            status, line_decoded = remove_strip_punctuation(line_decoded)
             if status and config['verbose']:
-                log.append(f'Remove_punctuation; punctuation removed; {line_decoded}{linesep}')
+                log.append(f'Remove_strip_punctuation; punctuation removed; {line_decoded}{linesep}')
 
         # We ran all modules
         if not stop:
@@ -939,8 +940,8 @@ def main():
         config['add-umlaut'] = True
 
     # Remove modules
-    if arguments.get('--remove-punctuation'):
-        config['remove-punctuation'] = True
+    if arguments.get('--remove-strip-punctuation'):
+        config['remove-strip-punctuation'] = True
 
     if arguments.get('--remove-email'):
         config['remove-email'] = True

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -88,6 +88,14 @@ Probably you do not want to change this option, it defaults to 'en_US.UTF-8'.
 But in case you want to change the output encoding, use this option.
 Note, this will change the internal python unicode encoding.
 
+punctuation
+~~~~~~~~~~~
+Use to set the punctuation that is use by options. For example used by the --remove-punctuation 
+option.
+
+Defaults to all ascci punctuation:
+! "#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+
 verbose
 ~~~~~~~
 Use the verbose option to log all the changes made to any line. Note that this will impact
@@ -248,10 +256,15 @@ tabs can be part of a password this option allows to disable this option.
 
 Remove modules
 --------------
+remove-strip-punctuation
+~~~~~~~~~~~~~~~~~~~~~~~~
+Remove starting and trailing punctuation. A line like: test- will be converted to
+test. This option is useful for language corpora.
+
 remove-punctuation
 ~~~~~~~~~~~~~~~~~~
-Remove start and end punctuation. A line like: test- will be converted to
-test. This option is useful for language corpora.
+Remove any punctuation from a line. A line like 'test - hi' will be converted to 'testhi'.
+What punctuation will be removed can be specified with the '--punctuation' option.
 
 remove-email
 ~~~~~~~~~~~~

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -307,6 +307,12 @@ to the corpora. Note: Add-split will not perform a length check that was specifi
 using the --min-length option. It only checks if the length of a split part is longer then
 1 unicode character.
 
+add-without-punctuation
+~~~~~~~~~~~~~~~~~~~~~~
+If a line contains punctuations, a variant will be added without the punctuations.
+Example a line like: 'test-123' will be kept, plus 'test123' will be added.
+Which punctuation will be removed can be specified with the --punctuation option.
+
 
 Macro modules
 -------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,3 +187,7 @@ with open('testdata/input27', 'w') as file:
 with open('testdata/input28', 'w') as file:
     file.write(f'stand_by_me{linesep}')
     file.write(f'the clash{linesep}')
+
+with open('testdata/input29', 'w') as file:
+    file.write(f'stand_by_me{linesep}')
+    file.write(f'the clash{linesep}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,3 +179,11 @@ with open('testdata/input25', 'w') as file:
 with open('testdata/input26', 'w') as file:
     file.write(f'polopaç{linesep}')
     file.write(f'mündster{linesep}')
+
+with open('testdata/input27', 'w') as file:
+    file.write(f'rip-it.up{linesep}')
+    file.write(f'orange juice{linesep}')
+
+with open('testdata/input28', 'w') as file:
+    file.write(f'stand_by_me{linesep}')
+    file.write(f'the clash{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -443,3 +443,31 @@ def test_clean_non_ascii():
         assert 'mündster' not in filecontent
         assert 'polopac' in filecontent
         assert 'mundster' in filecontent
+
+
+def test_remove_punctuation():
+    testargs = [
+        'demeuk', '-i', 'testdata/input27', '-o', 'testdata/output27', '-l', 'testdata/log27',
+        '--verbose', '--remove-punctuation',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output27') as f:
+        filecontent = f.read()
+
+        assert 'ripitup' in filecontent
+        assert 'orangejuice' in filecontent
+
+
+def test_remove_different_punctuation():
+    testargs = [
+        'demeuk', '-i', 'testdata/input28', '-o', 'testdata/output28', '-l', 'testdata/log28',
+        '--verbose', '--remove-punctuation', '--punctuation', '_',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output28') as f:
+        filecontent = f.read()
+
+        assert 'standbyme' in filecontent
+        assert 'the clash' in filecontent

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -179,7 +179,7 @@ def test_language_processing():
         'demeuk', '-i', 'testdata/input11', '-o', 'testdata/output11',
         '-l', 'testdata/log11',
         '--cut', '--delimiter', '/', '--cut-before', '--check-min-length', '2',
-        '--remove-punctuation', '--add-lower', '--add-latin-ligatures',
+        '--remove-strip-punctuation', '--add-lower', '--add-latin-ligatures',
         '--add-split',
     ]
     with patch.object(sys, 'argv', testargs):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -471,3 +471,19 @@ def test_remove_different_punctuation():
 
         assert 'standbyme' in filecontent
         assert 'the clash' in filecontent
+
+
+def test_add_without_punctuation():
+    testargs = [
+        'demeuk', '-i', 'testdata/input29', '-o', 'testdata/output29', '-l', 'testdata/log29',
+        '--verbose', '--add-without-punctuation',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output29') as f:
+        filecontent = f.read()
+
+        assert 'stand_by_me' in filecontent
+        assert 'the clash' in filecontent
+        assert 'standbyme' in filecontent
+        assert 'theclash' in filecontent

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     {[deps]test}
 commands =
     pytest
-    flake8 --ignore=''
+    flake8 --ignore='W605'
 
 [testenv:py3-dist]
 basepython = python3


### PR DESCRIPTION
Renaming '--remove-punctuation' to more suitable name: --remove-strip-punctuation
Adding --remove-punctuation which removes all punctuation and not only the starting and ending.
Adding --punctuation option to specify the set of punctuation's to be used by both options.