### PR TITLE
Flake8 without ignoring things

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""
+r"""
 .. code-block:: none
 
     Demeuk - a simple tool to clean up corpora

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     {[deps]test}
 commands =
     pytest
-    flake8 --ignore='W605'
+    flake8
 
 [testenv:py3-dist]
 basepython = python3


### PR DESCRIPTION
Run flake8 without ignoring the rule about invalid escape sequences by making the docstring a raw string