### PR TITLE
Install dependencies in advance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,8 @@ jobs:
           pip install setuptools wheel twine
       - name: Install package dependencies
         if: github.ref == 'refs/heads/master'
-        # Temporary duplication of the dependency list
         run: |
-          python -m pip install docopt chardet nltk ftfy unidecode tqdm
+          python -m pip install -r requirements.txt
       - name: Build and publish
         if: github.ref == 'refs/heads/master'
         env:


### PR DESCRIPTION
We need the dependencies to be able to run `setup.py`