### PR TITLE
Fix --check-email parameter removing invalid email adresses

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -118,7 +118,7 @@ from unidecode import unidecode
 version = '3.9.1'
 
 HEX_REGEX = re_compile(r'\$HEX\[([0-9a-f]+)\]')
-EMAIL_REGEX = '.{1,64}@([a-zA-Z0-9_-]*\\.){1,3}[a-zA-Z0-9_-]*'
+EMAIL_REGEX = '.{1,64}@([a-zA-Z0-9_-]{1,63}\\.){1,3}[a-zA-Z]{2,6}'
 HASH_HEX_REGEX = '^[a-fA-F0-9]+$'
 
 # Officiale bcrypt hashes hae a bit more fixed size, but saw some weird once:

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -115,7 +115,7 @@ from tqdm import tqdm
 from unidecode import unidecode
 
 
-version = '3.9.1'
+version = '3.9.2'
 
 HEX_REGEX = re_compile(r'\$HEX\[([0-9a-f]+)\]')
 EMAIL_REGEX = '.{1,64}@([a-zA-Z0-9_-]{1,63}\\.){1,3}[a-zA-Z]{2,6}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,3 +205,13 @@ with open('testdata/input32', 'w') as file:
 with open('testdata/input33', 'w') as file:
     file.write(f'invalidstring�{linesep}')
     file.write(f'jungejunge{linesep}')
+
+with open('testdata/input34', 'w') as file:
+    file.write(f'P@ssw0rd.1{linesep}')
+    file.write(f'bar@example.com{linesep}')
+    file.write(f'cr@ssT0rd{linesep}')
+    file.write(f'foo@example.com{linesep}')
+    file.write(f'p@..w0rd{linesep}')
+    file.write(f'p@..w0rd{linesep}')
+    file.write(f'p@ssW0rd.me@Home{linesep}')
+    file.write(f'w@ssB0rd.we{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -539,3 +539,21 @@ def test_check_replacement_character():
         filecontent = f.read()
         assert 'invalidstring�' not in filecontent
         assert 'jungejunge' in filecontent
+
+
+def test_email_detection():
+    testargs = [
+        'demeuk', '-i', 'testdata/input34', '-o', 'testdata/output34', '-l', 'testdata/log34',
+        '--verbose', '--check-email',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output34') as f:
+        filecontent = f.read()
+        assert 'bar@example.com' not in filecontent
+        assert 'foo@example.com' not in filecontent
+        assert 'p@ssW0rd.me@Home' not in filecontent
+        assert 'w@ssB0rd.we' not in filecontent
+        assert 'P@ssw0rd.1' in filecontent
+        assert 'cr@ssT0rd' in filecontent
+        assert 'p@..w0rd' in filecontent


### PR DESCRIPTION
The testcase is written in an alternative format, which is more comprehensive in finding (and showing) any kind of difference in expected output.