### PR TITLE
Fix multiline output when word contains CR

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -739,7 +739,7 @@ def clean_up(filename, chunk_start, chunk_size, config):
             status, cc = check_controlchar(line_decoded)
             if status:
                 # Control char detected
-                log.append(f'Check_controlchar; found controlchar {cc}; {line_decoded}{linesep}')
+                log.append(f'Check_controlchar; found controlchar {cc!r}; {line_decoded!r}{linesep}')
                 stop = True
 
         # Check if there are named html chars in the line


### PR DESCRIPTION
Multiline log outputs makes it hard to read/parse with standard CLI tooling.
Revert to python printable representation of string which is single line by
default.