### PR TITLE
 Add newline removal for HTML/HEX encoded entries

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -65,6 +65,7 @@ r"""
         --no-mojibake                   disable fixing mojibakes, useful if you know the encoding.
         --no-encode                     disable guessing of encoding, this force to use the --input-encoding.
         --no-tab                        disable replacing tab char with ':'
+        --no-newline                    disable removing newline characters (\r\n) from end and beginning.
         --non-ascii                     Replace non ascii char with their replacement letters. For example ü
                                         becomes u, ç becomes c.
 
@@ -542,6 +543,21 @@ def clean_html_named(line):
         return False, line
 
 
+def clean_newline(line):
+    """Delete newline characters at start and end of line
+
+    Params:
+        line (Unicode)
+    Returns:
+        line (Unicode)
+    """
+    return_line = line.strip('\r\n')
+    if return_line != line:
+        return True, return_line
+    else:
+        return False, line
+
+
 def check_controlchar(line):
     """Detects control chars, returns True when detected
 
@@ -733,6 +749,12 @@ def clean_up(filename, chunk_start, chunk_size, config):
             status, line_decoded = clean_mojibake(line_decoded)
             if status and config['verbose']:
                 log.append(f'Clean_mojibake; found a mojibake; {line}{linesep}')
+
+        # Delete leading and trailing newline characters
+        if config.get('newline') and not stop:
+            status, line_decoded = clean_newline(line_decoded)
+            if status and config['verbose']:
+                log.append(f'Clean_newline; deleted newline characters; {line_decoded!r}{linesep}')
 
         # Checks if there are any control chars inside line
         if config.get('check-controlchar') and not stop:
@@ -945,6 +967,7 @@ def main():
         'encode': True,
         'mojibake': True,
         'tab': True,
+        'newline': True,
         'hex': False,
         'html': False,
         'html-named': False,
@@ -1093,6 +1116,9 @@ def main():
 
     if arguments.get('--no-tab'):
         config['tab'] = False
+
+    if arguments.get('--no-newline'):
+        config['newline'] = False
 
     # Some meta-modules, those overwrite settings
     if arguments.get('--googlengram'):

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -116,7 +116,7 @@ from tqdm import tqdm
 from unidecode import unidecode
 
 
-version = '3.9.4'
+version = '3.9.5'
 
 HEX_REGEX = re_compile(r'\$HEX\[([0-9a-f]+)\]')
 EMAIL_REGEX = '.{1,64}@([a-zA-Z0-9_-]{1,63}\\.){1,3}[a-zA-Z]{2,6}'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -266,6 +266,11 @@ no-tab
 Defaulty demeuk will replace tab characters with ':' to make splitting easier. But in case
 tabs can be part of a password this option allows to disable this option.
 
+no-newline
+~~~~~~~~~~
+Defaulty demeuk will remove newline characters from encoded html/hex entries. But in case
+newlines can be part of a password this option allows to disable this option.
+
 
 
 Remove modules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,3 +215,15 @@ with open('testdata/input34', 'w') as file:
     file.write(f'p@..w0rd{linesep}')
     file.write(f'p@ssW0rd.me@Home{linesep}')
     file.write(f'w@ssB0rd.we{linesep}')
+
+with open('testdata/input35', 'w') as file:
+    file.write(f'Avocado{linesep}')
+    file.write(f'Banana\\r\\n{linesep}')
+    file.write(f'Coconut\\n{linesep}')
+    file.write(f'$HEX[447261676f6e66727569740d0a]{linesep}')
+    file.write(f'$HEX[456c64657262657272790d]{linesep}')
+    file.write(f'Fig<br>{linesep}')
+    file.write(f'Grapefruit&#013;{linesep}')
+    file.write(f'Honeyberry&#010;{linesep}')
+    file.write(f'Icaco&#013;&#010;{linesep}')
+    file.write(f'&#013;Jambul{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -557,3 +557,24 @@ def test_email_detection():
         assert 'P@ssw0rd.1' in filecontent
         assert 'cr@ssT0rd' in filecontent
         assert 'p@..w0rd' in filecontent
+
+
+def test_newline_replacement():
+    testargs = [
+        'demeuk', '-i', 'testdata/input35', '-o', 'testdata/output35', '-l', 'testdata/log35',
+        '--verbose', '--hex', '--html',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output35') as f:
+        filecontent = f.read()
+        assert 'Avocado\n' in filecontent
+        assert '\nBanana\\r\\n\n' in filecontent
+        assert '\nCoconut\\n\n' in filecontent
+        assert '\nDragonfruit\n' in filecontent
+        assert '\nElderberry\n' in filecontent
+        assert '\nFig<br>\n' in filecontent
+        assert '\nGrapefruit\n' in filecontent
+        assert '\nHoneyberry\n' in filecontent
+        assert '\nIcaco\n' in filecontent
+        assert '\nJambul' in filecontent


### PR DESCRIPTION
Newlines encoded by HTML or HEX are often introduced by incorrect parsing of
files with different newlines format e.g. windows (\r\n), unix (\n) or mac (\r)
and re-encoding them.

This erroneously introduced newlines should be trimmed to avoid being flagged
as control characters (ignoring the entry).