### PR TITLE
Fixing invalid unhexing

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -99,7 +99,6 @@ from locale import LC_ALL, setlocale
 from multiprocessing import cpu_count, current_process, Pool
 from os import linesep, mkdir, path, walk
 from re import compile as re_compile
-from re import IGNORECASE
 from re import search
 from re import split as re_split
 from re import sub
@@ -123,7 +122,7 @@ version = '3.9.7'
 
 # Search from start to finish for the string $HEX[], with block of a-f0-9 with even number
 # of hex chars. The first match group is repeated.
-HEX_REGEX = re_compile(r"^\$HEX\[(([0-9a-f][0-9a-f])+)\]$", IGNORECASE)
+HEX_REGEX = re_compile(r"^\$(?:HEX|hex)\[((?:[0-9a-fA-F]{2})+)\]$")
 EMAIL_REGEX = '.{1,64}@([a-zA-Z0-9_-]{1,63}\\.){1,3}[a-zA-Z]{2,6}'
 HASH_HEX_REGEX = '^[a-fA-F0-9]+$'
 

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -99,6 +99,7 @@ from locale import LC_ALL, setlocale
 from multiprocessing import cpu_count, current_process, Pool
 from os import linesep, mkdir, path, walk
 from re import compile as re_compile
+from re import IGNORECASE
 from re import search
 from re import split as re_split
 from re import sub
@@ -118,9 +119,11 @@ from tqdm import tqdm
 from unidecode import unidecode
 
 
-version = '3.9.6'
+version = '3.9.7'
 
-HEX_REGEX = re_compile(r'\$HEX\[([0-9a-f]+)\]')
+# Search from start to finish for the string $HEX[], with block of a-f0-9 with even number
+# of hex chars. The first match group is repeated.
+HEX_REGEX = re_compile(r"^\$HEX\[(([0-9a-f][0-9a-f])+)\]$", IGNORECASE)
 EMAIL_REGEX = '.{1,64}@([a-zA-Z0-9_-]{1,63}\\.){1,3}[a-zA-Z]{2,6}'
 HASH_HEX_REGEX = '^[a-fA-F0-9]+$'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,6 @@ with open('testdata/input36', 'w') as file:
 
 with open('testdata/input37', 'w') as file:
     file.write(f'$HEX[e]tiredofwaiting{linesep}')
-    file.write(f'$HEX[6C6F73696E67746F756368]{linesep}')
+    file.write(f'$hex[6C6F73696E67746F756368]{linesep}')
     file.write(f'$HEX[6C657469746B69636B696E]123!{linesep}')
     file.write(f'$HEX[eee]{linesep}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,3 +246,9 @@ with open('testdata/input36', 'w') as file:
     file.write(f'<br>snooker\\r{linesep}')
     file.write(f'<br><br />tchoukball{linesep}')
     file.write(f'vigoro{linesep}')
+
+with open('testdata/input37', 'w') as file:
+    file.write(f'$HEX[e]tiredofwaiting{linesep}')
+    file.write(f'$HEX[6C6F73696E67746F756368]{linesep}')
+    file.write(f'$HEX[6C657469746B69636B696E]123!{linesep}')
+    file.write(f'$HEX[eee]{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -606,3 +606,23 @@ def test_trim():
         assert '\nsnooker\n' in filecontent
         assert '\ntchoukball\n' in filecontent
         assert '\nvigoro' in filecontent
+
+
+def test_invalid_unhex():
+    testargs = [
+        'demeuk', '-i', 'testdata/input37', '-o', 'testdata/output37', '-l', 'testdata/log37',
+        '--verbose', '--hex',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+
+    with open('testdata/output37') as f:
+        filecontent = f.read()
+        # Invalid hex string, leaving at as is.
+        assert '$HEX[e]tiredofwaiting\n' in filecontent
+        # Invalid hex string, leaving at as is.
+        assert '\n$HEX[eee]\n' in filecontent
+        # This is a valid hash, but it is not a hex string from start to end.
+        assert '\n$HEX[6C657469746B69636B696E]123!\n' in filecontent
+        # Valid upcase test
+        assert '\nlosingtouch\n' in filecontent


### PR DESCRIPTION
Bug fix on the `--hex` option. The following strings resulted in an 'Odd string' error:

`$hex[e]`
`$hex[eee]`

Also I noticed that the regex did not match uppercase letters like:
`$HEX[EEEE]`

Another error I encountered:
`$HEX[EEEE]123!`

Completly dropped the `123!` part. I forced the regex to only match on the complete string, making it match both uppercase and lowercase and only even hex strings.
