### PR TITLE
Adding skip, check-starting-with and check-empty-line

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -58,6 +58,7 @@ r"""
         --check-replacement-character   Drop lines containing replacement characters '�'.
         --check-starting-with <string>  Drop lines starting with string, can be multiple strings. Specify multiple
                                         with as comma-seperated list.
+        --check-empty-line              Drop lines that are empty or only contain whitespace characters
 
     Modify modules (modify a line in place):
         --hex                           Replace lines like: $HEX[41424344] with ABCD.
@@ -463,6 +464,21 @@ def check_starting_with(line, strings):
     for string in strings:
         if line.startswith(string):
             return True
+    return False
+
+
+def check_empty_line(line):
+    """Checks if a line is empty or only contains whitespace chars
+
+    Params:
+        line (unicode)
+    Returns:
+        true of line is empty or only contains whitespace chars
+    """
+    if line == '':
+        return True
+    elif line.isspace():
+        return True
     return False
 
 
@@ -897,6 +913,12 @@ def clean_up(filename, chunk_start, chunk_size, config):
                 log.append(f'Check_starting_with; dropped line because {to_check} found; {line_decoded}{linesep}')
                 stop = True
 
+        if config.get('check-empty-line') and not stop:
+            if check_empty_line(line_decoded):
+                log_line = "Check_empty_line; dropped line because is empty or only contains whitespace;"
+                log.append(f'{log_line} {line_decoded}{linesep}')
+                stop = True
+
         if config.get('remove-punctuation') and not stop:
             status, line_decoded = remove_punctuation(line_decoded, config.get('punctuation'))
             if status and config['verbose']:
@@ -1056,6 +1078,7 @@ def main():
         'check-non-ascii': False,
         'check-replacement-character': False,
         'check-starting-with': False,
+        'check-empty-line': False,
 
         # Add
         'add-lower': False,
@@ -1157,6 +1180,9 @@ def main():
             config['check-starting-with'] = arguments.get('--check-starting-with').split(',')
         else:
             config['check-starting-with'] = [arguments.get('--check-starting-with')]
+
+    if arguments.get('--check-empty-line'):
+        config['check-empty-line'] = True
 
     # Add modules
     if arguments.get('--add-lower'):

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -122,7 +122,7 @@ from tqdm import tqdm
 from unidecode import unidecode
 
 
-version = '3.9.7'
+version = '3.10.0'
 
 # Search from start to finish for the string $HEX[], with block of a-f0-9 with even number
 # of hex chars. The first match group is repeated.

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -29,6 +29,7 @@ r"""
                                         also line which were modified.
         --progress                      Prints out the progress of the demeuk process.
         -n --limit <int>                Limit the number of lines per thread.
+        -s --skip <int>                 Skip <int> amount of lines per thread.
         --punctuation <punctuation>     Use to set the punctuation that is use by options. Defaults to:
                                         ! "#$%&'()*+,-./:;<=>?@[\]^_`{|}~
         --version                       Prints the version of demeuk.
@@ -737,7 +738,6 @@ def clean_up(filename, chunk_start, chunk_size, config):
             status, line = clean_tab(line)
             if status and config['verbose']:
                 log.append(f'Clean_tab; replaced tab characters; {line}{linesep}')
-
         # Converting enoding to UTF-8
         if config.get('encode') and not stop:
             status, line_decoded = clean_encode(line, config.get('input_encoding'))
@@ -958,6 +958,8 @@ def chunkify(fname, config, size=1024 * 1024):
             continue
         fileend = path.getsize(filename)
         with open(filename, 'br') as f:
+            for x in range(0, config.get('skip')):
+                f.readline()
             chunkend = f.tell()
             while True:
                 chunkstart = chunkend
@@ -1005,6 +1007,7 @@ def main():
         'verbose': False,
         'progress': False,
         'limit': False,
+        'skip': False,
 
         # Modify
         'encode': True,
@@ -1051,6 +1054,9 @@ def main():
 
     if arguments.get('--limit'):
         config['limit'] = int(arguments.get('--limit'))
+
+    if arguments.get('--skip'):
+        config['skip'] = int(arguments.get('--skip'))
 
     if arguments.get('--input-encoding'):
         config['input_encoding'] = arguments.get('--input-encoding').split(',')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -213,6 +213,13 @@ The problem is that with this char all information is lost about the original ch
 So it is very complicated to repair this encoding error. With this option you can drop
 lines contain this char.
 
+check-starting-with
+~~~~~~~~~~~~~~~~~~~
+Checks if a line start with the argument of checking-starting-with. If the line starts
+with this, it will be dropped. The string to check can be multiple strings. multiple
+values are comma-seperated. Example: #,// would skip lines starting with '#' and with 
+'//'.
+
 Modify modules
 --------------
 hex

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -115,6 +115,10 @@ that if you set the limit to 5 and create 2 threads, 10 lines will be processed.
 entirely true, if the input file is too small (minimal chunk size) to spawn two threads the
 limit will only apply to the only thread that could be spawned.
 
+n skip
+~~~~~~
+Skip n lines starting from the start of the file.
+
 
 Separating options
 ------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -220,6 +220,15 @@ with this, it will be dropped. The string to check can be multiple strings. mult
 values are comma-seperated. Example: #,// would skip lines starting with '#' and with 
 '//'.
 
+If you want to drop a line starting with a tab, add ':' to the list of strings to
+check. '--check starting-with :'. By default tab characters are transfered to ':'.
+To disable this behavior use the --no-tab option.
+
+check-empty-line
+~~~~~~~~~~~~~~~~
+Checks if a line only contains whitespace characters or is empty. If this is true,
+the line will be dropped.
+
 Modify modules
 --------------
 hex

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,5 +256,13 @@ with open('testdata/input37', 'w') as file:
 with open('testdata/input38', 'w') as file:
     file.write(f'112345678{linesep}')
     file.write(f'#firstlovesong{linesep}')
+    file.write(f'/secondlovesong{linesep}')
+    file.write(f'{linesep}')
+    file.write(f'lastlovesong{linesep}')
+
+with open('testdata/input39', 'w') as file:
+    file.write(f'112345678{linesep}')
+    file.write(f'#firstlovesong{linesep}')
+    file.write(f'/secondlovesong{linesep}')
     file.write(f'{linesep}')
     file.write(f'lastlovesong{linesep}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,3 +252,9 @@ with open('testdata/input37', 'w') as file:
     file.write(f'$hex[6C6F73696E67746F756368]{linesep}')
     file.write(f'$HEX[6C657469746B69636B696E]123!{linesep}')
     file.write(f'$HEX[eee]{linesep}')
+
+with open('testdata/input38', 'w') as file:
+    file.write(f'112345678{linesep}')
+    file.write(f'#firstlovesong{linesep}')
+    file.write(f'{linesep}')
+    file.write(f'lastlovesong{linesep}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -258,6 +258,7 @@ with open('testdata/input38', 'w') as file:
     file.write(f'#firstlovesong{linesep}')
     file.write(f'/secondlovesong{linesep}')
     file.write(f'{linesep}')
+    file.write(f'\tcaliforniastars{linesep}')
     file.write(f'lastlovesong{linesep}')
 
 with open('testdata/input39', 'w') as file:
@@ -265,4 +266,13 @@ with open('testdata/input39', 'w') as file:
     file.write(f'#firstlovesong{linesep}')
     file.write(f'/secondlovesong{linesep}')
     file.write(f'{linesep}')
+    file.write(f'\tcaliforniastars{linesep}')
+    file.write(f'lastlovesong{linesep}')
+
+with open('testdata/input40', 'w') as file:
+    file.write(f'112345678{linesep}')
+    file.write(f'#firstlovesong{linesep}')
+    file.write(f'/secondlovesong{linesep}')
+    file.write(f'{linesep}')
+    file.write(f'\tcaliforniastars{linesep}')
     file.write(f'lastlovesong{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -626,3 +626,19 @@ def test_invalid_unhex():
         assert '\n$HEX[6C657469746B69636B696E]123!\n' in filecontent
         # Valid upcase test
         assert '\nlosingtouch\n' in filecontent
+
+
+def test_skip():
+    testargs = [
+        'demeuk', '-i', 'testdata/input38', '-o', 'testdata/output38', '-l', 'testdata/log38',
+        '--verbose', '--skip', '1'
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+
+    with open('testdata/output38') as f:
+        filecontent = f.read()
+
+    assert '112345678' not in filecontent
+
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -642,16 +642,32 @@ def test_skip():
     assert '112345678' not in filecontent
 
 
-def test_remove_starting_with():
+def test_check_starting_with():
     testargs = [
-        'demeuk', '-i', 'testdata/input38', '-o', 'testdata/output38', '-l', 'testdata/log38',
-        '--verbose', '--check-starting-with', '/,#'
+        'demeuk', '-i', 'testdata/input39', '-o', 'testdata/output39', '-l', 'testdata/log39',
+        '--verbose', '--check-starting-with', '/,#,:'
     ]
     with patch.object(sys, 'argv', testargs):
         main()
 
-    with open('testdata/output38') as f:
+    with open('testdata/output39') as f:
         filecontent = f.read()
 
     assert 'firstlovesong' not in filecontent
     assert 'secondlovesong' not in filecontent
+    assert 'californiastars' not in filecontent
+    assert '\n\n' in filecontent
+
+
+def test_check_empty_line():
+    testargs = [
+        'demeuk', '-i', 'testdata/input40', '-o', 'testdata/output40', '-l', 'testdata/log40',
+        '--verbose', '--check-empty-line',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+
+    with open('testdata/output40') as f:
+        filecontent = f.read()
+
+    assert '\n\n' not in filecontent

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -642,3 +642,16 @@ def test_skip():
     assert '112345678' not in filecontent
 
 
+def test_remove_starting_with():
+    testargs = [
+        'demeuk', '-i', 'testdata/input38', '-o', 'testdata/output38', '-l', 'testdata/log38',
+        '--verbose', '--check-starting-with', '/,#'
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+
+    with open('testdata/output38') as f:
+        filecontent = f.read()
+
+    assert 'firstlovesong' not in filecontent
+    assert 'secondlovesong' not in filecontent


### PR DESCRIPTION
Adding 3 news options

--skip <n> allows you the skip n lines from the start of your file.

--check-starting-with <str>,<str>,... allows you to specific a list of string separated by a comma. If a line start with the string specified the line will be dropped.

--check-empty-line checks if a line is empty or only contains whitespace characters.