### PR TITLE
Use __token__ auth for publish step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Build and publish
         if: github.ref == 'refs/heads/master'
         env:
-          TWINE_USERNAME: fbda
-          TWINE_PASSWORD: ${{ secrets.PYPI_FBDA_PASSWORD }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           python setup.py sdist bdist_wheel
           twine upload dist/*


### PR DESCRIPTION
Organization secret with account password was reset and removed, added a repo secret scoped for this project instead.