### PR TITLE
Adding support for comma selecting of elements when using cut for example -c -f 1,3

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -144,7 +144,7 @@ from tqdm import tqdm
 from unidecode import unidecode
 
 
-version = '4.2.0'
+version = '4.2.1'
 
 # Search from start to finish for the string $HEX[], with block of a-f0-9 with even number
 # of hex chars. The first match group is repeated.
@@ -594,9 +594,20 @@ def clean_cut(line, delimiters, fields):
                 if stop == '':
                     stop = len(line)
                 fields = slice(int(start) - 1, int(stop))
+                return True, delimiter.join(line.split(delimiter)[fields])
+            # Small loop to add support for 1,3 for example to select the
+            # 1st and 3th element.
+            elif ',' in fields:
+                elements = [int(x) for x in fields.split(',')]
+                return_line = []
+                line = line.split(delimiter)
+                for element in elements:
+                    return_line.append(line[element - 1])
+
+                return True, delimiter.join(return_line)
             else:
                 fields = slice(int(fields) - 1, int(fields))
-            return True, delimiter.join(line.split(delimiter)[fields])
+                return True, delimiter.join(line.split(delimiter)[fields])
     else:
         return False, line
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -833,3 +833,16 @@ def test_check_lowercase():
         filecontent = f.read()
 
     assert '3 doors down' in filecontent
+
+
+def test_cut_comma_fields():
+    testargs = [
+        'demeuk', '-i', 'testdata/input13', '-o', 'testdata/output49', '-l', 'testdata/log49',
+        '-f', '2,4', '-c',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+    with open('testdata/output49') as f:
+        filecontent = f.read()
+        assert 'field2:field4\n' in filecontent
+        assert 'field3' not in filecontent


### PR DESCRIPTION
With the pull request you can do -c -f 1,3 -d ':' to select field 1 and 3 from a file, for example:

field1:field2:field3 

With -c -f 1,3 -d ':' would return:

field1:field3