### PR TITLE
Added check if contains option.

### DIFF
--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -171,7 +171,7 @@ from tqdm import tqdm
 from unidecode import unidecode
 
 
-version = '4.4.0'
+version = '4.5.0'
 
 # Search from start to finish for the string $HEX[], with block of a-f0-9 with even number
 # of hex chars. The first match group is repeated.

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -66,6 +66,8 @@ r"""
                                         with as comma-seperated list.
         --check-ending-with <string>    Drop lines ending with string, can be multiple strings. Specify multiple
                                         with as comma-seperated list.
+        --check-if-contains <string>    Drop lines containing string, can be multiple strings. Specify multiple
+                                        with as comma-seperated list.
         --check-empty-line              Drop lines that are empty or only contain whitespace characters
         --check-regex <string>          Drop lines that do not match the regex. Regex is a comma seperated list of
                                         regexes. Example: [a-z]{1,8},[0-9]{1,8}
@@ -575,6 +577,23 @@ def check_ending_with(line, strings):
     """
     for string in strings:
         if line.endswith(string):
+            return True
+    return False
+
+
+def check_contains(line, strings):
+    """Checks if a line does not contain specific strings
+
+    Params:
+        line (unicode)
+        strings[str]
+
+    Returns:
+        true if line does contain any one of the strings
+
+    """
+    for string in strings:
+        if string in line:
             return True
     return False
 
@@ -1195,6 +1214,12 @@ def clean_up(lines):
                 log.append(f'Check_ending_with; dropped line because {to_check} found; {line_decoded}{linesep}')
                 stop = True
 
+        if config.get('check-if-contains') and not stop:
+            to_check = config.get("check-if-contains")
+            if check_contains(line_decoded, to_check):
+                log.append(f'Check-if-contains; dropped line because {to_check} found; {line_decoded}{linesep}')
+                stop = True
+
         if config.get('check-empty-line') and not stop:
             if check_empty_line(line_decoded):
                 log_line = "Check_empty_line; dropped line because is empty or only contains whitespace;"
@@ -1340,6 +1365,7 @@ def main():
         'check-starting-with': False,
         'check-uuid': False,
         'check-ending-with': False,
+        'check-if-contains': False,
         'check-empty-line': False,
         'check-regex': False,
         'check-min-digits': 0,
@@ -1497,6 +1523,12 @@ def main():
             config['check-ending-with'] = arguments.get('--check-ending-with').split(',')
         else:
             config['check-ending-with'] = [arguments.get('--check-ending-with')]
+
+    if arguments.get('--check-if-contains'):
+        if ',' in arguments.get('--check-if-contains'):
+            config['check-if-contains'] = arguments.get('--check-if-contains').split(',')
+        else:
+            config['check-if-contains'] = [arguments.get('--check-if-contains')]
 
     if arguments.get('--check-empty-line'):
         config['check-empty-line'] = True

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -66,7 +66,7 @@ r"""
                                         with as comma-seperated list.
         --check-ending-with <string>    Drop lines ending with string, can be multiple strings. Specify multiple
                                         with as comma-seperated list.
-        --check-contains <string>    Drop lines containing string, can be multiple strings. Specify multiple
+        --check-contains <string>       Drop lines containing string, can be multiple strings. Specify multiple
                                         with as comma-seperated list.
         --check-empty-line              Drop lines that are empty or only contain whitespace characters
         --check-regex <string>          Drop lines that do not match the regex. Regex is a comma seperated list of

--- a/bin/demeuk.py
+++ b/bin/demeuk.py
@@ -66,7 +66,7 @@ r"""
                                         with as comma-seperated list.
         --check-ending-with <string>    Drop lines ending with string, can be multiple strings. Specify multiple
                                         with as comma-seperated list.
-        --check-if-contains <string>    Drop lines containing string, can be multiple strings. Specify multiple
+        --check-contains <string>    Drop lines containing string, can be multiple strings. Specify multiple
                                         with as comma-seperated list.
         --check-empty-line              Drop lines that are empty or only contain whitespace characters
         --check-regex <string>          Drop lines that do not match the regex. Regex is a comma seperated list of
@@ -1214,10 +1214,10 @@ def clean_up(lines):
                 log.append(f'Check_ending_with; dropped line because {to_check} found; {line_decoded}{linesep}')
                 stop = True
 
-        if config.get('check-if-contains') and not stop:
-            to_check = config.get("check-if-contains")
+        if config.get('check-contains') and not stop:
+            to_check = config.get("check-contains")
             if check_contains(line_decoded, to_check):
-                log.append(f'Check-if-contains; dropped line because {to_check} found; {line_decoded}{linesep}')
+                log.append(f'Check-contains; dropped line because {to_check} found; {line_decoded}{linesep}')
                 stop = True
 
         if config.get('check-empty-line') and not stop:
@@ -1365,7 +1365,7 @@ def main():
         'check-starting-with': False,
         'check-uuid': False,
         'check-ending-with': False,
-        'check-if-contains': False,
+        'check-contains': False,
         'check-empty-line': False,
         'check-regex': False,
         'check-min-digits': 0,
@@ -1524,11 +1524,11 @@ def main():
         else:
             config['check-ending-with'] = [arguments.get('--check-ending-with')]
 
-    if arguments.get('--check-if-contains'):
-        if ',' in arguments.get('--check-if-contains'):
-            config['check-if-contains'] = arguments.get('--check-if-contains').split(',')
+    if arguments.get('--check-contains'):
+        if ',' in arguments.get('--check-contains'):
+            config['check-contains'] = arguments.get('--check-contains').split(',')
         else:
-            config['check-if-contains'] = [arguments.get('--check-if-contains')]
+            config['check-contains'] = [arguments.get('--check-contains')]
 
     if arguments.get('--check-empty-line'):
         config['check-empty-line'] = True

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -292,9 +292,19 @@ characters are transfered to ':'.
 check-ending-with
 ~~~~~~~~~~~~~~~~~
 Checks if a line ends with the argument of check-ending-with. If the line ends
-with this, the line will be dropped. The string to check can be multiple strings. multiple
+with this, the line will be dropped. The string to check can be multiple strings. Multiple
 values are comma-seperated. Example: #,// would skip lines ending with '#' and with 
 '//'.
+
+If you enabled the '--tab' option and you want to drop lines ending with a tab, add
+':' to the list of strings to check. '--check ending-with :'. When using --tab tab
+characters are transfered to ':'.
+
+check-contains
+~~~~~~~~~~~~~~
+Checks if a line contains the argument of check-contains. If the line contains this,
+the line will be dropped. The string to check can be multiple strings. Multiple values
+are comma-separated. Example: #,// would skip lines containing '#' and '//'.
 
 If you enabled the '--tab' option and you want to drop lines ending with a tab, add
 ':' to the list of strings to check. '--check ending-with :'. When using --tab tab

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -322,6 +322,13 @@ matches all of the regexes, the line will be dropped.
 Example: --check-regex '[a-z],[0-9]' will drop lines
 that do not atleast contain one lowercase char and one number.
 
+Want to remove a line that does not contain an underscore?
+--check-regex '^[^_]+$'
+
+Want to remove a line that start with a specific strings?
+--check-regex '^[^this]' will remove lines starting with 'this'
+
+
 check-min-digits
 ~~~~~~~~~~~~~~~~
 Checks if a line contains a minimum number of digit characters. If the line does not contain

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,7 +389,7 @@ with open('testdata/input52', 'w') as file:
     file.write(f'Cookie Monster {linesep}')
 
 with open('testdata/input53', 'w') as file:
-    file.write(f'three00000down {linesep}')
-    file.write(f'00000amsterdam {linesep}')
-    file.write(f'ROTTERDAM00000 {linesep}')
+    file.write(f'three_down {linesep}')
+    file.write(f'_amsterdam {linesep}')
+    file.write(f'ROTTERDAM_ {linesep}')
     file.write(f'Cookie Monster {linesep}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,3 +387,9 @@ with open('testdata/input52', 'w') as file:
     file.write(f'amsterdam {linesep}')
     file.write(f'ROTTERDAM {linesep}')
     file.write(f'Cookie Monster {linesep}')
+
+with open('testdata/input53', 'w') as file:
+    file.write(f'three00000down {linesep}')
+    file.write(f'00000amsterdam {linesep}')
+    file.write(f'ROTTERDAM00000 {linesep}')
+    file.write(f'Cookie Monster {linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -970,7 +970,7 @@ def test_add_title_case():
 def test_check_contains():
     testargs = [
         'demeuk', '-i', 'testdata/input53', '-o', 'testdata/output53', '-l', 'testdata/log53',
-        '--verbose', '--check-contains 00000',
+        '--verbose', '--check-contains', '_',
     ]
     with patch.object(sys, 'argv', testargs):
         main()
@@ -978,4 +978,7 @@ def test_check_contains():
     with open('testdata/output53') as f:
         filecontent = f.read()
 
+    assert 'three_down' not in filecontent
+    assert '_amsterdam' not in filecontent
+    assert 'ROTTERDAM_' not in filecontent
     assert 'Cookie Monster' in filecontent

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -965,3 +965,17 @@ def test_add_title_case():
     assert 'Amsterdam' in filecontent
     assert 'Rotterdam' in filecontent
     assert 'Cookie Monster' in filecontent
+
+
+def test_check_contains():
+    testargs = [
+        'demeuk', '-i', 'testdata/input53', '-o', 'testdata/output53', '-l', 'testdata/log53',
+        '--verbose', '--check-contains 00000',
+    ]
+    with patch.object(sys, 'argv', testargs):
+        main()
+
+    with open('testdata/output53') as f:
+        filecontent = f.read()
+
+    assert 'Cookie Monster' in filecontent


### PR DESCRIPTION
Check if a certain term is present in line and remove the line if this is the case. This option is needed for chases which cannot be solved with the regex, starts-with or ends-with. 