### PR TITLE
Add uppercase module

### DIFF
--- a/src/demeuk/modules/add/capitalization.py
+++ b/src/demeuk/modules/add/capitalization.py
@@ -36,3 +36,14 @@ class TitleCaseModule(AddModule):
     def run(self, line):
         add_line = line.title()
         return self.get_result(line, add_line)
+
+class UpperAddModule(AddModule):
+    @staticmethod
+    def get_help_info():
+        return HelpInfo(
+            option='add-upper',
+            help_str='Add a variant of the line which is all uppercased')
+
+    def run(self, line):
+        add_line = line.upper()
+        return self.get_result(line, add_line)

--- a/src/demeuk/modules/modify/case.py
+++ b/src/demeuk/modules/modify/case.py
@@ -24,3 +24,14 @@ class TitleCaseModule(ModifyModule):
     def run(self, line):
         cleaned_line = line.title()
         return self.get_result(line, cleaned_line)
+
+class UppercaseModule(ModifyModule):
+    @staticmethod
+    def get_help_info():
+        return HelpInfo(
+            option='uppercase',
+            help_str="Replace line like 'this test string' with 'THIS TEST STRING'.")
+
+    def run(self, line):
+        cleaned_line = line.upper()
+        return self.get_result(line, cleaned_line)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -406,3 +406,9 @@ with open('testdata/input56', 'w') as file:
     file.write(f'demeuk@example.com:password1{linesep}')
     file.write(f'demeuk@example.com:test@example.com{linesep}')
     file.write(f'1238661:test@example.com:password{linesep}')
+
+with open('testdata/input57', 'w') as file:
+    file.write(f'all lower{linesep}')
+    file.write(f'ALL UPPER{linesep}')
+    file.write(f'MixeD cAsE{linesep}')
+    file.write(f'unicode caße{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1002,3 +1002,19 @@ def test_order():
     assert 'test@example.com' not in results
     assert 'password1' in results
     assert 'password' in results
+
+def test_upper():
+    results = _run_demeuk(57, '--uppercase')
+    assert len(results) == 4
+    assert 'ALL LOWER' in results
+    assert 'ALL UPPER' in results
+    assert 'MIXED CASE' in results
+    assert 'UNICODE CASSE' in results
+
+def test_add_upper():
+    results = _run_demeuk(57, '--add-upper')
+    assert len(results) == 7
+    assert 'ALL LOWER' in results
+    assert 'ALL UPPER' in results
+    assert 'MIXED CASE' in results
+    assert 'UNICODE CASSE' in results


### PR DESCRIPTION
Adds two uppercasing modules

- `--uppercase` capitalizes every character.
- `--add-upper` keeps the original line, and adds a uppercased version of the line.

This uses Python's builtin `upper()` function, which follows Unicode's case folding spec. This means that 'ß' will be converted to 'SS' for example.