### PR TITLE
Remove empty result of remove modules

### DIFF
--- a/src/demeuk/modules/remove/remove.py
+++ b/src/demeuk/modules/remove/remove.py
@@ -20,6 +20,12 @@ class RemoveModule(Module):
         :type result: Result
         :return: Actions object which updates the line
         """
+        if result.update == '':
+            # If all characters got removed, do not include an empty line
+            # but delete the line from the queue instead
+            return Actions(
+                stop=True,
+                debug_str='removed line')
         return Actions(
             update=result.update,
             debug_str=result.msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -406,3 +406,8 @@ with open('testdata/input56', 'w') as file:
     file.write(f'demeuk@example.com:password1{linesep}')
     file.write(f'demeuk@example.com:test@example.com{linesep}')
     file.write(f'1238661:test@example.com:password{linesep}')
+
+with open('testdata/input58', 'w') as file:
+    file.write(f'line{linesep}')
+    file.write(f'.{linesep}')
+    file.write(f'+{linesep}')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1002,3 +1002,7 @@ def test_order():
     assert 'test@example.com' not in results
     assert 'password1' in results
     assert 'password' in results
+
+def test_remove_emptyline():
+    results = _run_demeuk(58, '--remove-punctuation')
+    assert len(results) == 1


### PR DESCRIPTION
Bugfix for https://github.com/NetherlandsForensicInstitute/demeuk/issues/32

If the result of a remove module is an empty line, don't include it in the results.